### PR TITLE
log output accordingly : either --log or stdout

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,14 +1,20 @@
 use log::{Log, LogRecord, LogLevel, LogMetadata};
 use std::io::{Write, stderr};
+use std::fs::OpenOptions;
 
-pub struct SimpleLogger;
+pub struct SimpleLogger{
+    pub logfile: String
+}
+
 
 impl Log for SimpleLogger {
+
     fn enabled(&self, metadata: &LogMetadata) -> bool {
         metadata.level() <= LogLevel::Debug
     }
 
     fn log(&self, record: &LogRecord) {
+        if &(*self.logfile)[..] == ""{
         if self.enabled(record.metadata()) {
             let _ = writeln!(
                 &mut stderr(),
@@ -17,5 +23,11 @@ impl Log for SimpleLogger {
                 record.args()
             );
         }
+        }
+        else{
+        if let Ok(mut f) = OpenOptions::new().append(true).open(&(*self.logfile)[..]) {
+            f.write_all(format!{"{} = {}\n", record.level(), record.args()}.as_bytes()).unwrap();
+        }
+    }
     }
 }


### PR DESCRIPTION
Was unable to get debug log to logfile.
Hence, added a value 'logfile' to SimpleLogger log checks if the value of --log attribute is empty or not.
If there is a value, it writes to the mentioned file, else it goes to stderr/stdout.
