### PR TITLE
fixed build warning about unnecessary mutable 'let mut pfds = '

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1628,7 +1628,7 @@ fn wait_for_pipe_vec(
 ) -> Result<(Vec<u8>)> {
     let mut result = Vec::new();
     while result.len() < num {
-        let mut pfds =
+        let pfds =
             &mut [PollFd::new(rfd, POLLIN | POLLHUP, EventFlags::empty())];
         match poll(pfds, timeout) {
             Err(e) => {


### PR DESCRIPTION
Build was complaining that **pfds** does not need to be mutable.

Have made it immutable instead.